### PR TITLE
Include the name of the project in query title

### DIFF
--- a/app/models/query_presenter.rb
+++ b/app/models/query_presenter.rb
@@ -10,7 +10,11 @@ class QueryPresenter < SimpleDelegator
   end
 
   def title
-    "#{name} (#{issue_count})"
+    if project.nil?
+      "#{name} (#{issue_count})"
+    else
+      "#{project.name} - #{name} (#{issue_count})"
+    end
   end
 
   def link(title)

--- a/test/unit/query_presenter_test.rb
+++ b/test/unit/query_presenter_test.rb
@@ -23,6 +23,13 @@ class QueryPresenterTest < ActionView::TestCase
     assert_equal title, @query_presenter.title
   end
 
+  def test_title_with_project
+    project_query = Query.find(7)
+    project_query_presenter = QueryPresenter.new(project_query, view)
+    title = "#{project_query.project.name} - #{project_query.name} (#{project_query.issue_count})"
+    assert_equal title, project_query_presenter.title
+  end
+
   def test_link
     assert_equal '<a href="/issues?query_id=5">title</a>',
                  @query_presenter.link('title')


### PR DESCRIPTION
This is more consistent with the block selection dropdown and is less
confusing when different projects have queries with similar names.